### PR TITLE
Replace (deprecated) username/password login by OAuth2 login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PoliteUsersBot
 Reddit Bot made in python
 
-To run this bot on your own replace the USERNAME, PASSWORD, and USERAGENT variables in the politeusersbot.py file.
+To run this bot on your own replace the USERAGENT variable in the politeusersbot.py file. Then go on Reddit, create an app and fill in the 'clientid' and 'clientsecret' variables. Run the app once and fill in the 'authcode' variable and you should be good to go.
 
 You can view the reddit bot live by checking out it's user profile [here](https://www.reddit.com/user/Polite_Users_Bot/)

--- a/politeusersbot.py
+++ b/politeusersbot.py
@@ -1,9 +1,25 @@
 Giimport praw
 import time
 
+#Configuration options.
+
+#OAuth config. See https://praw.readthedocs.io/en/stable/pages/oauth.html for more info.
+#Get a client id and client secret by creating an app on Reddit
+clientid = ""
+clientsecret = ""
+#Leave this empty at first, then run the script. Do the thing on Reddit, then enter the 'code' hex
+#key from the 127.0.0.1 url here.
+authcode = ""
+
 r = praw.Reddit(user_agent = "A bot to thank users for being nice on reddit created by /u/kooldawgstar")
 print("Logging in...")
-r.login("USERNAME","PASSWORD", disable_warnings = True)
+r.set_oauth_app_info(client_id=clientid,client_secret=clientsecret,redirect_uri='http://127.0.0.1:65010/authorize_callback')
+if authcode == "":
+    url = r.get_authorize_url('uniqueKey', 'identity read submit', True)
+    print("URL: "+url)
+    exit(0)
+access_information = r.get_access_information(authcode)
+r.set_access_credentials(**access_information)
 
 words_to_match = ['Please', 'thank you', 'You are welcome', 'May I', 'Excuse me', 'Pardon me', 'sorry', 'thanks ', ' thanks']
 cache = []


### PR DESCRIPTION
While I may not like the current behaviour of your bot very much, I would not like it to get banned on a technicality either. The current Reddit API guidelines insist on authenticating using OAuth2, while your code still uses an username/password combo. This patch changes this into a proper OAuth2 login. Fyi, this code is adapted from PoliteUserBotBots sources.
